### PR TITLE
Add calendar to home page

### DIFF
--- a/home.html
+++ b/home.html
@@ -59,7 +59,7 @@
           Meetings occur every other Thursday at 5pm and are
           located in the Statistics Building, room 008 (conference room in the basement).
         </p>
-        </div>
+        <iframe src="https://calendar.google.com/calendar/embed?showTitle=0&amp;showPrint=0&amp;showTabs=0&amp;showCalendars=0&amp;showTz=0&amp;height=600&amp;wkst=1&amp;bgcolor=%23ffffff&amp;src=fqstv3gri9n03s65cij0rj0k4k%40group.calendar.google.com&amp;color=%23125A12&amp;ctz=America%2FDenver" style="border-width:0" width="800" height="600" frameborder="0" scrolling="no"></iframe>        </div>
       </div>
     </section>
 


### PR DESCRIPTION
There is now a google calendar embed on the home page. The calendar is sourced from dawson's google account.